### PR TITLE
fix: fix compare

### DIFF
--- a/src/utils/contracts.ts
+++ b/src/utils/contracts.ts
@@ -22,8 +22,7 @@ function compare(symbolX: string, symbolY: string) {
     if (elem_cmp != EQUAL) return elem_cmp;
     i++;
   }
-  const lenCmp = cmp(symbolX.length, symbolY.length);
-  return lenCmp;
+  return cmp(symbolX.length, symbolY.length);
 }
 
 export function isSortedSymbols(symbolX: string, symbolY: string) {

--- a/src/utils/contracts.ts
+++ b/src/utils/contracts.ts
@@ -16,17 +16,14 @@ function cmp(a: number, b: number) {
 }
 
 function compare(symbolX: string, symbolY: string) {
-  const lenCmp = cmp(symbolX.length, symbolY.length);
-  if (lenCmp != EQUAL) {
-    return lenCmp;
-  }
   let i = 0;
   while (i < symbolX.length && i < symbolY.length) {
     const elem_cmp = cmp(symbolX.charCodeAt(i), symbolY.charCodeAt(i));
     if (elem_cmp != EQUAL) return elem_cmp;
     i++;
   }
-  return EQUAL;
+  const lenCmp = cmp(symbolX.length, symbolY.length);
+  return lenCmp;
 }
 
 export function isSortedSymbols(symbolX: string, symbolY: string) {


### PR DESCRIPTION
Fixes 

fix `compare` function.

`compare` function should be same with `aptos_std::comparator`.
```move
public fun compare_u8_vector(left: vector<u8>, right: vector<u8>): Result {
      let left_length = vector::length(&left);
      let right_length = vector::length(&right);

      let idx = 0;

      while (idx < left_length && idx < right_length) {
          let left_byte = *vector::borrow(&left, idx);
          let right_byte = *vector::borrow(&right, idx);

          if (left_byte < right_byte) {
              return Result { inner: SMALLER }
          } else if (left_byte > right_byte) {
              return Result { inner: GREATER }
          };
          idx = idx + 1;
      };

      if (left_length < right_length) {
          Result { inner: SMALLER }
      } else if (left_length > right_length) {
          Result { inner: GREATER }
      } else {
          Result { inner: EQUAL }
      }
  }
```
