### PR TITLE
slippage fix

### DIFF
--- a/src/modules/SwapModule.ts
+++ b/src/modules/SwapModule.ts
@@ -163,11 +163,11 @@ export class SwapModule implements IModule {
     const fromAmount =
       params.interactiveToken === 'from'
         ? params.fromAmount
-        : withSlippage(params.slippage, params.fromAmount).toFixed(0);
+        : withSlippage(params.slippage, params.fromAmount, true).toFixed(0);
     const toAmount =
       params.interactiveToken === 'to'
         ? params.toAmount
-        : withSlippage(params.slippage, params.toAmount).toFixed(0);
+        : withSlippage(params.slippage, params.toAmount, false).toFixed(0);
 
     const args = [fromAmount.toString(), toAmount.toString()];
 

--- a/src/utils/contracts.ts
+++ b/src/utils/contracts.ts
@@ -130,11 +130,10 @@ export function composeType(address: string, ...args: unknown[]): string {
  * and the price at which the trade is executed.
  * @param {Decimal} value - value to calculate slippage
  */
-export function withSlippage(slippage: Decimal, value: Decimal) {
+export function withSlippage(slippage: Decimal, value: Decimal, isPlussed: boolean) {
   const multiply = new Decimal(10000);
   const slippagePercent = slippage.mul(multiply);
-
-  return value.minus(value.mul(slippagePercent).div(multiply)).toNumber();
+  return isPlussed ? value.plus(value.mul(slippagePercent).div(multiply)).toNumber() : value.minus(value.mul(slippagePercent).div(multiply)).toNumber();
 }
 
 export function extractAddressFromType(type: string) {


### PR DESCRIPTION
If the interactive token is 'from", slippage correctly minus the amount of 'to' token.
But if the interactive token is 'to', slippage should plus the amount 'from' token (not 'minus').
With your implementation there is "ERR_COIN_VAL_MAX_LESS_THAN_NEEDED(0xce):' error, because the amount of from token is minused instead of plused.