### PR TITLE
Feature add v.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ For Yarn:
           CoinInfo: '0x1::coin::CoinInfo', - Type of base CoinInfo module
           CoinStore: '0x1::coin::CoinStore', - Type of base CoinStore module
         },
+        resourceAccount: '0x05a97986a9d031c4567e15b797be516910cfcb4156312482efc6a19c0a30c948',
+        moduleAccount: '0x190d44266241744264b964a37b8f09863167a12d3e70cda39376cfb4e3561e12',
+        moduleAccountV05: '0x163df34fccbf003ce219d3f1d9e70d140b60622cb9dd47599c25fb2f797ba6e',
+        resourceAccountV05: '0x61d2c22a6cb7831bee0f48363b0eec92369357aece0d1142062f7d5d85c7bef8'
       }
     */
   })
@@ -288,6 +292,61 @@ For Yarn:
 
     console.log(output); // true
   })
+  ```
+</details>
+
+<details>
+  <summary>Pools v.0.5: Swap 0.8 LayerZero USDT to LayerZero USDC</summary>
+
+  ```typescript
+  (async () => {
+    // Get USDT amount
+    try {
+      const output = await sdk.Swap.calculateRates({
+        fromToken: '0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDC', //layerzero USDC
+        toToken: '0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDT', // layerzero USDT
+        amount: 800000, // 0.8 USDC, or you can use convertValueToDecimal(0.8, 6)
+        curveType: 'stable', // can be 'uncorrelated' or 'stable'
+        interactiveToken: 'from', // which token is 'base' to calculate other token rate.
+        version: 0.5 // optional, version could be only 0 or 0.5. If not provided version is 0
+      })
+      console.log(output) // '601018' (0.601018 USDT)
+
+      // Generate TX payload for swap 0.8 USDC to maximum 0.601018 USDT
+      // and minimum 0.598013 USDT (with slippage -0.5%)
+      const txPayload = sdk.Swap.createSwapTransactionPayload({
+        fromToken: '0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDC',
+        toToken: '0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDT', // layerzero USDT
+        fromAmount: 800000, // 0.8 USDT, or you can use convertValueToDecimal(0.8, 6)
+        toAmount: 601018, // 0.601018 USDC, or you can use convertValueToDecimal(0.601018, 6)
+        interactiveToken: 'from',
+        slippage: 0.005, // 0.5% (1 - 100%, 0 - 0%)
+        stableSwapType: 'high',
+        curveType: 'stable',
+        version: 0.5,
+      })
+      console.log(txPayload);
+    } catch(e) {
+      console.log(e)
+    }
+
+    /**
+     Output:
+     {
+        "arguments": [
+          "800000",
+          "598013"
+        ],
+        "function": "0x163df34fccbf003ce219d3f1d9e70d140b60622cb9dd47599c25fb2f797ba6e::scripts::swap",
+        "type": "entry_function_payload",
+        "type_arguments": [
+          "0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDC",
+          "0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDT",
+          "0x163df34fccbf003ce219d3f1d9e70d140b60622cb9dd47599c25fb2f797ba6e::curves::Stable"
+        ]
+      }
+    */
+  })()
   ```
 </details>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pontem/liquidswap-sdk",
-  "version": "0.5.7",
+  "version": "0.6.0",
   "description": "SDK to use LiquidSwap functions",
   "author": "Igor Demko <igor@pontem.network>",
   "repository": "https://github.com/pontem-network/liquidswap-sdk",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -23,6 +23,6 @@ export const TOKENS_MAPPING: Record<string, string> = {
   APTOS: '0x1::aptos_coin::AptosCoin',
   USDT: '0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDT', //layerzero USDT
   BTC: '0xae478ff7d83ed072dbc5e264250e67ef58f57c99d89b447efd8a0a2e8b2be76e::coin::T', // wormhole wrapped BTC
-  WETH: '0xcc8a89c8dce9693d354449f1f73e60e14e347417854f029db5bc8e7454008abb::coin::T', // wormhole WETH
+  WETH: '0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::WETH', // LayerZero WETH
   USDC: '0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDC', // layerzero USDC
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,9 +1,16 @@
 export const MODULES_ACCOUNT = '0x190d44266241744264b964a37b8f09863167a12d3e70cda39376cfb4e3561e12';
 export const RESOURCES_ACCOUNT = '0x05a97986a9d031c4567e15b797be516910cfcb4156312482efc6a19c0a30c948';
 export const COINS_ACCOUNT = '0x43417434fd869edee76cca2a4d2301e528a1551b1d719b75c350c3c97d15b8b9';
+export const MODULES_V05_ACCOUNT = '0x163df34fccbf003ce219d3f1d9e70d140b60622cb9dd47599c25fb2f797ba6e';
+export const RESOURCES_V05_ACCOUNT = '0x61d2c22a6cb7831bee0f48363b0eec92369357aece0d1142062f7d5d85c7bef8';
 
 export const COIN_INFO = '0x1::coin::CoinInfo';
 export const COIN_STORE = '0x1::coin::CoinStore';
+
+export const SCRIPTS_V1 = 'scripts';
+export const SCRIPTS_V2 = 'scripts_v2';
+export const VERSION_0 = 0;
+export const VERSION_0_5 = 0.5;
 
 export const NETWORKS_MODULES = {
   Scripts: `${MODULES_ACCOUNT}::scripts_v2`,

--- a/src/modules/SwapModule.ts
+++ b/src/modules/SwapModule.ts
@@ -14,8 +14,8 @@ import {
   is_sorted,
   withSlippage,
 } from '../utils';
-import {VERSION_0, VERSION_0_5} from "../constants";
-import {getCurve} from "../utils/contracts";
+import { VERSION_0, VERSION_0_5 } from "../constants";
+import { getCurve } from "../utils/contracts";
 
 export type CalculateRatesParams = {
   fromToken: AptosResourceType;
@@ -23,7 +23,7 @@ export type CalculateRatesParams = {
   amount: Decimal | number;
   interactiveToken: 'from' | 'to';
   curveType: CurveType;
-  version: typeof VERSION_0 | typeof VERSION_0_5;
+  version?: typeof VERSION_0 | typeof VERSION_0_5;
 };
 
 export type CreateTXPayloadParams = {
@@ -35,7 +35,7 @@ export type CreateTXPayloadParams = {
   slippage: number;
   stableSwapType: 'high' | 'normal';
   curveType: CurveType;
-  version: typeof VERSION_0 | typeof VERSION_0_5;
+  version?: typeof VERSION_0 | typeof VERSION_0_5;
 }
 
 type GetLiquidityPoolResourceParams = Pick<CalculateRatesParams, 'fromToken' | 'toToken' | 'curveType' | 'version'>;
@@ -181,7 +181,7 @@ export class SwapModule implements IModule {
         : 'swap_into',
     );
 
-    const curve = curves[params.curveType];
+    const curve = getCurve(params.curveType, curves, params.version);
 
     const typeArguments = [params.fromToken, params.toToken, curve];
 
@@ -231,7 +231,6 @@ export class SwapModule implements IModule {
         : [coinY, coinX];
       return composeType(modulesLiquidityPool, [sortedX, sortedY, curve]);
     }
-    // const curve = curves[params.curveType];
 
     const liquidityPoolType = getPoolStr(
       params.fromToken,

--- a/src/modules/SwapModule.ts
+++ b/src/modules/SwapModule.ts
@@ -169,8 +169,13 @@ export class SwapModule implements IModule {
 
     const { modules } = this.sdk.networkOptions;
 
+
+
+
     const isUnchecked =
-      params.curveType === 'stable' && params.stableSwapType === 'normal';
+      params.version === VERSION_0 &&
+      params.curveType === 'stable' &&
+      params.stableSwapType === 'normal';
 
     const functionName = composeType(
       modules.Scripts,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -3,7 +3,7 @@ import { SwapModule } from './modules/SwapModule';
 import { ResourcesModule } from './modules/ResourcesModule';
 import { AptosResourceType } from './types/aptos';
 import { LiquidityModule } from './modules/LiquidityModule';
-import { NETWORKS_MODULES, MODULES_ACCOUNT, RESOURCES_ACCOUNT } from './constants';
+import { NETWORKS_MODULES, MODULES_ACCOUNT, RESOURCES_ACCOUNT, MODULES_V05_ACCOUNT, RESOURCES_V05_ACCOUNT } from './constants';
 
 const initialNetworkOptions = {
   nativeToken: '0x1::aptos_coin::AptosCoin',
@@ -14,6 +14,8 @@ const initialNetworkOptions = {
   },
   resourceAccount: RESOURCES_ACCOUNT,
   moduleAccount: MODULES_ACCOUNT,
+  moduleAccountV05: MODULES_V05_ACCOUNT,
+  resourceAccountV05: RESOURCES_V05_ACCOUNT
 };
 
 interface INetworkOptions {
@@ -25,6 +27,8 @@ interface INetworkOptions {
   } & Record<string, AptosResourceType>;
   resourceAccount?: string;
   moduleAccount?: string;
+  moduleAccountV05?: string;
+  resourceAccountV05?: string;
 }
 
 export interface SdkOptions {
@@ -32,9 +36,11 @@ export interface SdkOptions {
   networkOptions?: INetworkOptions;
 }
 
-interface ICurves {
+export interface ICurves {
   stable: string;
   uncorrelated: string;
+  stableV05: string;
+  uncorrelatedV05: string;
 }
 
 export class SDK {
@@ -91,7 +97,9 @@ export class SDK {
     this._liquidity = new LiquidityModule(this);
     this._curves = {
       uncorrelated: `${this._networkOptions.moduleAccount}::curves::Uncorrelated`,
-      stable: `${this._networkOptions.moduleAccount}::curves::Stable`
+      stable: `${this._networkOptions.moduleAccount}::curves::Stable`,
+      uncorrelatedV05: `${this._networkOptions.moduleAccountV05}::curves::Uncorrelated`,
+      stableV05: `${this._networkOptions.resourceAccountV05}::curves::Stable`
     }
   }
 }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -99,7 +99,7 @@ export class SDK {
       uncorrelated: `${this._networkOptions.moduleAccount}::curves::Uncorrelated`,
       stable: `${this._networkOptions.moduleAccount}::curves::Stable`,
       uncorrelatedV05: `${this._networkOptions.moduleAccountV05}::curves::Uncorrelated`,
-      stableV05: `${this._networkOptions.resourceAccountV05}::curves::Stable`
+      stableV05: `${this._networkOptions.moduleAccountV05}::curves::Stable`
     }
   }
 }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -90,6 +90,12 @@ export class SDK {
       if (options.networkOptions?.resourceAccount) {
         this._networkOptions.resourceAccount = options.networkOptions.resourceAccount;
       }
+      if (options.networkOptions?.moduleAccountV05) {
+        this._networkOptions.moduleAccountV05 = options.networkOptions.moduleAccountV05;
+      }
+      if (options.networkOptions?.resourceAccountV05) {
+        this._networkOptions.resourceAccountV05 = options.networkOptions.resourceAccountV05;
+      }
     }
     this._client = new AptosClient(options.nodeUrl);
     this._swap = new SwapModule(this);

--- a/src/utils/contracts.ts
+++ b/src/utils/contracts.ts
@@ -1,7 +1,17 @@
 import { Buffer } from 'buffer';
 import Decimal from 'decimal.js';
 
+import { ICurves } from '../sdk';
+
+import {
+  VERSION_0_5,
+  VERSION_0,
+  SCRIPTS_V1,
+  SCRIPTS_V2,
+} from '../constants';
+
 import { checkAddress } from './hex';
+import {CurveType} from "../types/aptos";
 
 const EQUAL = 0;
 const LESS_THAN = 1;
@@ -196,4 +206,45 @@ export function checkAptosType(
     parts[1].length >= 1 &&
     parts[2].length >= 1
   );
+}
+
+/**
+ * Get Script Modules Name for a Contract Version
+ *
+ * @throws Unknown contract version requested
+ *
+ * @param contract version number
+ * @returns script with scripts module name value
+ */
+export function getScriptsFor(version: number): string {
+  if (version === VERSION_0_5) return SCRIPTS_V1;
+  switch (version) {
+    case VERSION_0:
+      return SCRIPTS_V2;
+    case VERSION_0_5:
+      return SCRIPTS_V1;
+  }
+  throw new Error('Unknown contract version requested');
+}
+
+/**
+ * Compute full curve type for given contract version
+ *
+ * @param type short name of curve
+ * @param contract version
+ * @param curves curves from sdk
+ * @returns curve full type
+ *
+ */
+export function getCurve(type: CurveType, curves: ICurves, contract?: number): string {
+  if (contract === VERSION_0_5) {
+    if (type === 'stable') {
+      return curves.stableV05;
+    }
+    return curves.uncorrelatedV05;
+  }
+  if (type === 'uncorrelated') {
+    return curves.stable;
+  }
+  return curves.uncorrelated;
 }

--- a/src/utils/contracts.ts
+++ b/src/utils/contracts.ts
@@ -243,7 +243,7 @@ export function getCurve(type: CurveType, curves: ICurves, contract?: number): s
     }
     return curves.uncorrelatedV05;
   }
-  if (type === 'uncorrelated') {
+  if (type === 'stable') {
     return curves.stable;
   }
   return curves.uncorrelated;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -14,7 +14,6 @@ export {
   calcReceivedLP,
   calcOutputBurnLiquidity,
   getOptimalLiquidityAmount,
-  getPoolLpStr,
   getPoolStr,
 } from './liquidity';
 export {

--- a/src/utils/liquidity.ts
+++ b/src/utils/liquidity.ts
@@ -1,7 +1,6 @@
 import { Decimal } from 'decimal.js';
 
 import { d } from './numbers';
-import { RESOURCES_ACCOUNT } from '../constants';
 import { is_sorted, composeType } from './contracts';
 
 /**
@@ -80,23 +79,6 @@ export function getOptimalLiquidityAmount(
   yReserve: Decimal,
 ): Decimal {
   return xDesired.mul(yReserve).div(xReserve);
-}
-
-export function getPoolLpStr(
-  coinX: string,
-  coinY: string,
-  curve: string,
-): string {
-  const [sortedX, sortedY] = is_sorted(coinX, coinY)
-    ? [coinX, coinY]
-    : [coinY, coinX];
-  return composeType(
-    //
-    RESOURCES_ACCOUNT,
-    'lp_coin',
-    'LP',
-    [sortedX, sortedY, curve],
-  );
 }
 
 export function getPoolStr(


### PR DESCRIPTION
In order to work with pools version v.0.5 it is necessary to provide two additional parameters to 'networkOptions' in SDK init:
resourceAccountV05 - resource account for v.0.5 pools
moduleAccountV05 - module account for v.0.5 pools

Also added new parameter 'version' for functions like calculateRates, getAmountIn, getAmountOut, and createSwapTransactionPayload.
'version' could be only 0 or 0.5 as number;
This parameter optional. if not provided - it treats like version is 0. 
If provided version 0.5 - resourceAccountV05 and moduleAccountV05 will be used for calculations of reserves and curves.

- [x] Tests pass
